### PR TITLE
[st-10058] Include txes with schema attributes

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,1 @@
-((nil . ((cider-clojure-cli-global-options . "-A:dev:test:jdbc:datomic-pro:postgresql"))))
+((nil . ((cider-clojure-cli-global-options . "-A:dev:jdbc:datomic-cloud:postgresql"))))

--- a/src/lambdaisland/plenish_cloud/queries.clj
+++ b/src/lambdaisland/plenish_cloud/queries.clj
@@ -101,6 +101,16 @@
        (map first)
        set))
 
+(defn ids-of-schema-attrs [datomic-conn]
+  (->> #{:db/ident :db/valueType :db/cardinality :db/unique}
+       (d/q '[:find ?e
+              :in $ [?attr ...]
+              :where
+              [?e :db/ident ?attr]]
+            (d/db datomic-conn))
+       (map first)
+       set))
+
 (defn filter-datoms-by-attrs
   [attrs txes]
   (->> txes


### PR DESCRIPTION
When importing a missing table we still need the txes about schema changes so that ctx can be updated during the import and create columns as needed.